### PR TITLE
完善设置密码的代码(MODE_EDIT)

### DIFF
--- a/example/src/main/java/com/example/gesturelock/MainActivity.java
+++ b/example/src/main/java/com/example/gesturelock/MainActivity.java
@@ -67,11 +67,26 @@ public class MainActivity extends Activity {
             }
 
             @Override
+            public void onFinishGestureInput(int[] inputGestures) {
+                String str = "";
+                for(int i=0; i<inputGestures.length; i++){
+                    str = str + String.valueOf(inputGestures[i]) + ", ";
+                }
+                Log.d("gestures", "inputGestures=" + str );
+
+                gestureView.clear();
+            }
+
+            @Override
             public void onBlockSelected(int position) {
                 Log.d("position", position + "");
             }
 
         });
+
+        //gestureView.updateCorrectGestures(new int[]{0, 1, 2});
+        gestureView.setMode(GestureLock.MODE_NORMAL);
+        //gestureView.setMode(GestureLock.MODE_EDIT);
     }
 
     @Override

--- a/gesturelock/src/main/java/com/sevenheaven/gesturelock/GestureLock.java
+++ b/gesturelock/src/main/java/com/sevenheaven/gesturelock/GestureLock.java
@@ -56,10 +56,15 @@ public class GestureLock extends ViewGroup {
     private OnGestureEventListener onGestureEventListener;
     private GestureLockAdapter mAdapter;
 
+    /**
+     * on MODE_EDIT mode, only onFinishGestureInput() & onBlockSelected() will be called
+     * on MODE_NORMAL mode, all function will be called
+     */
     public interface OnGestureEventListener{
         void onBlockSelected(int position);
         void onGestureEvent(boolean matched);
         void onUnmatchedExceedBoundary();
+        void onFinishGestureInput(int[] inputGestures);
     }
 
     /**
@@ -142,6 +147,14 @@ public class GestureLock extends ViewGroup {
         if(defaultGestures.length > negativeGestures.length) throw new IllegalArgumentException("defaultGestures length must be less than or equal to " + negativeGestures.length);
 
         unmatchedBoundary = mAdapter.getUnmatchedBoundary();
+    }
+
+    /**
+     * update correct gestures directly, not only by adapter define
+     * @param correctGestures
+     */
+    public void updateCorrectGestures(int[] correctGestures){
+        defaultGestures = correctGestures;
     }
 
     public void notifyDataChanged(){
@@ -357,6 +370,9 @@ public class GestureLock extends ViewGroup {
                     if (gesturesContainer[0] != -1) {
                         boolean matched = false;
 
+                        //本次输入串
+                        onGestureEventListener.onFinishGestureInput(gesturesContainer.clone());
+
                         if (gesturesContainer.length == defaultGestures.length || gesturesContainer[defaultGestures.length] == -1) {
                             for (int j = 0; j < defaultGestures.length; j++) {
                                 if (gesturesContainer[j] == defaultGestures[j]) {
@@ -392,12 +408,17 @@ public class GestureLock extends ViewGroup {
                             unmatchedCount = 0;
                         }
 
+                        if(mode != MODE_EDIT){
+                            unmatchedCount = 0;
+                        }
 
-                        if (onGestureEventListener != null) {
-                            onGestureEventListener.onGestureEvent(matched);
-                            if (unmatchedCount >= unmatchedBoundary) {
-                                onGestureEventListener.onUnmatchedExceedBoundary();
-                                unmatchedCount = 0;
+                        if(mode==MODE_NORMAL) {
+                            if (onGestureEventListener != null) {
+                                onGestureEventListener.onGestureEvent(matched);
+                                if (unmatchedCount >= unmatchedBoundary) {
+                                    onGestureEventListener.onUnmatchedExceedBoundary();
+                                    unmatchedCount = 0;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
在设置密码时，不要触发以下方法回调
        void onGestureEvent(boolean matched);
        void onUnmatchedExceedBoundary();

增加MODE_EDIT(设置密码)专用的方法回调：
       void onFinishGestureInput(int[] inputGestures);
开发者可以在这里记录客户录入的密码，自行保存（例如保存到SharedPreference，用于MODE_NORMAL下的比对）。

